### PR TITLE
Test: 단위 테스트, API 통합 테스트, 검증 테스트

### DIFF
--- a/event-api/build.gradle.kts
+++ b/event-api/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.testImplementation
+
 plugins {
     kotlin("plugin.spring")
     id("org.springframework.boot")
@@ -10,9 +12,14 @@ dependencies {
     implementation(project(":event-application"))
     implementation(project(":event-storage"))
 
-    implementation("org.springframework.boot:spring-boot-starter-validation")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0")
     implementation("io.projectreactor:reactor-core")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation("org.assertj:assertj-core:3.25.3")
+    testImplementation("io.projectreactor:reactor-test")
 }

--- a/event-api/src/main/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/controller/EventController.kt
+++ b/event-api/src/main/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/controller/EventController.kt
@@ -1,6 +1,6 @@
 package com.jeffreyoh.eventapi.adapter.inbound.web.controller
 
-import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventRequest
+import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventDTO
 import com.jeffreyoh.eventapi.adapter.inbound.web.handler.EventHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Valid
@@ -22,7 +22,7 @@ class EventController(
 
     @PostMapping
     fun receiveEvent(
-        @RequestBody @Valid request: SaveEventRequest
+        @RequestBody @Valid request: SaveEventDTO.SaveEventRequest
     ): Mono<ResponseEntity<Void>> {
         log.debug { "Received API request: $request" }
         return eventHandler.saveEvent(request)

--- a/event-api/src/main/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/dto/SaveEventRequest.kt
+++ b/event-api/src/main/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/dto/SaveEventRequest.kt
@@ -3,31 +3,50 @@ package com.jeffreyoh.eventapi.adapter.inbound.web.dto
 import com.jeffreyoh.eventcore.domain.event.EventCommand
 import com.jeffreyoh.eventcore.domain.event.EventMetadata
 import com.jeffreyoh.eventcore.domain.event.EventType
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-data class SaveEventRequest(
-    @field:NotBlank
-    val eventType: String,
+class SaveEventDTO {
 
-    val userId: Long?,
+    data class SaveEventRequest(
+        @field:NotBlank
+        val eventType: String,
 
-    @field:NotBlank
-    val sessionId: String,
+        val userId: Long?,
 
-    @field:NotNull
-    val metadata: EventMetadata,
-) {
-    fun toCommand(): EventCommand.SaveEventCommand {
-        return EventCommand.SaveEventCommand(
-            eventType.toEventTypeOrThrow(),
-            userId,
-            sessionId,
-            metadata
-        )
+        @field:NotBlank
+        val sessionId: String,
+
+        @field:Valid
+        val metadata: EventMetadataRequest,
+    ) {
+        fun toCommand(): EventCommand.SaveEventCommand {
+            return EventCommand.SaveEventCommand(
+                eventType.toEventTypeOrThrow(),
+                userId,
+                sessionId,
+                EventMetadata(
+                    metadata.componentId,
+                    metadata.elementId,
+                    metadata.targetUrl,
+                    metadata.pageUrl,
+                    metadata.keyword,
+                )
+            )
+        }
     }
+
+    data class EventMetadataRequest(
+        val componentId: Long, // 요소 값이 가변적일 수 있으므로 실질적인 ID 별도 저장
+        @field:NotBlank val elementId: String, // 프론트에서 사용하는 요소 값
+        @field:NotBlank val targetUrl: String? = null,
+        @field:NotBlank val pageUrl: String? = null,
+        @field:NotBlank val keyword: String? = null,
+    )
+
 }
 
 // 확장 함수

--- a/event-api/src/main/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/handler/EventHandler.kt
+++ b/event-api/src/main/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/handler/EventHandler.kt
@@ -1,6 +1,6 @@
 package com.jeffreyoh.eventapi.adapter.inbound.web.handler
 
-import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventRequest
+import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventDTO
 import com.jeffreyoh.eventport.input.SaveEventUseCase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Component
@@ -13,7 +13,7 @@ class EventHandler(
     private val saveEventUseCase: SaveEventUseCase
 ) {
 
-    fun saveEvent(request: SaveEventRequest): Mono<Void> {
+    fun saveEvent(request: SaveEventDTO.SaveEventRequest): Mono<Void> {
         log.debug { "Handling event at handler level: $request" }
         return saveEventUseCase.saveEvent(request.toCommand())
     }

--- a/event-api/src/test/kotlin/com/jeffreyoh/eventapi/EventControllerValidationTest.kt
+++ b/event-api/src/test/kotlin/com/jeffreyoh/eventapi/EventControllerValidationTest.kt
@@ -1,0 +1,125 @@
+package com.jeffreyoh.eventapi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jeffreyoh.eventapi.adapter.inbound.web.controller.EventController
+import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventDTO
+import com.jeffreyoh.eventapi.adapter.inbound.web.handler.EventHandler
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@WebFluxTest(controllers = [EventController::class])
+class EventControllerValidationTest {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var eventHandler: EventHandler
+
+    @Test
+    fun `eventType 이 공백이면 400`() {
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = "", // ❌
+            sessionId = "session-123",
+            userId = 1L,
+            metadata = SaveEventDTO.EventMetadataRequest(1000L, "element-123", "https://jeffrey-oh.click")
+        )
+
+        postAndExpectBadRequest(request)
+    }
+
+    @Test
+    fun `sessionId 가 공백이면 400`() {
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = "CLICK",
+            sessionId = " ", // ❌
+            userId = 1L,
+            metadata = SaveEventDTO.EventMetadataRequest(1000L, "element-123", "https://jeffrey-oh.click")
+        )
+
+        postAndExpectBadRequest(request)
+    }
+
+    @Test
+    fun `metadata-elementId 가 빈 문자열이면 400`() {
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = "CLICK",
+            sessionId = "session-123",
+            userId = 1L,
+            metadata = SaveEventDTO.EventMetadataRequest(
+                componentId = 1000L,
+                elementId = "", // ❌
+                targetUrl = "https://jeffrey-oh.click"
+            )
+        )
+
+        postAndExpectBadRequest(request)
+    }
+
+    @Test
+    fun `metadata-targetUrl 이 공백이면 400`() {
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = "CLICK",
+            sessionId = "session-123",
+            userId = 1L,
+            metadata = SaveEventDTO.EventMetadataRequest(
+                componentId = 1000L,
+                elementId = "element-123",
+                targetUrl = "  " // ❌
+            )
+        )
+
+        postAndExpectBadRequest(request)
+    }
+
+    @Test
+    fun `metadata-pageUrl 이 공백이면 400`() {
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = "CLICK",
+            sessionId = "session-123",
+            userId = 1L,
+            metadata = SaveEventDTO.EventMetadataRequest(
+                componentId = 1000L,
+                elementId = "element-123",
+                pageUrl = "  " // ❌
+            )
+        )
+
+        postAndExpectBadRequest(request)
+    }
+
+    @Test
+    fun `metadata-keyword 이 공백이면 400`() {
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = "CLICK",
+            sessionId = "session-123",
+            userId = 1L,
+            metadata = SaveEventDTO.EventMetadataRequest(
+                componentId = 1000L,
+                elementId = "element-123",
+                keyword = "  " // ❌
+            )
+        )
+
+        postAndExpectBadRequest(request)
+    }
+
+    private fun postAndExpectBadRequest(request: SaveEventDTO.SaveEventRequest) {
+        val json = objectMapper.writeValueAsString(request)
+
+        webTestClient.post()
+            .uri("/api/events")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(json)
+            .exchange()
+            .expectStatus().isBadRequest
+    }
+
+}

--- a/event-api/src/test/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/controller/EventControllerTest.kt
+++ b/event-api/src/test/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/controller/EventControllerTest.kt
@@ -1,0 +1,60 @@
+package com.jeffreyoh.eventapi.adapter.inbound.web.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventDTO
+import com.jeffreyoh.eventapi.adapter.inbound.web.handler.EventHandler
+import com.jeffreyoh.eventcore.domain.event.EventType
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.reactive.server.WebTestClient
+import reactor.core.publisher.Mono
+
+@WebFluxTest(controllers = [EventController::class])
+class EventControllerTest {
+
+    @Autowired
+    private lateinit var webTestClient: WebTestClient
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var eventHandler: EventHandler
+
+    @Test
+    fun `이벤트 저장 요청이 handler 로 전달된다`() {
+        // given
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = EventType.CLICK.name,
+            sessionId = "session-123",
+            userId = 1,
+            metadata = SaveEventDTO.EventMetadataRequest(
+                componentId = 1000,
+                elementId = "element-123",
+                targetUrl = "https://jeffrey-oh.click"
+            )
+        )
+
+        val json = objectMapper.writeValueAsString(request)
+
+        given(eventHandler.saveEvent(request)).willReturn(Mono.empty())
+
+        // when
+        webTestClient.post()
+            .uri("/api/events")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(json)
+            .exchange()
+            .expectStatus().isCreated
+
+        // then
+        verify(eventHandler, times(1)).saveEvent(request)
+    }
+
+}

--- a/event-api/src/test/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/handler/EventHandlerTest.kt
+++ b/event-api/src/test/kotlin/com/jeffreyoh/eventapi/adapter/inbound/web/handler/EventHandlerTest.kt
@@ -1,0 +1,55 @@
+package com.jeffreyoh.eventapi.adapter.inbound.web.handler
+
+import com.jeffreyoh.eventapi.adapter.inbound.web.dto.SaveEventDTO
+import com.jeffreyoh.eventcore.domain.event.EventType
+import com.jeffreyoh.eventport.input.SaveEventUseCase
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+@ExtendWith(MockKExtension::class)
+class EventHandlerTest {
+
+    @MockK private lateinit var saveEventUseCase: SaveEventUseCase
+    private lateinit var eventHandler: EventHandler
+
+    @BeforeEach
+    fun setUp() {
+        eventHandler = EventHandler(saveEventUseCase)
+    }
+
+    @Test
+    fun `이벤트 저장 요청을 usecase 로 전달한다`() {
+        // given
+        val request = SaveEventDTO.SaveEventRequest(
+            eventType = EventType.CLICK.name,
+            sessionId = "session-123",
+            userId = null,
+            metadata = SaveEventDTO.EventMetadataRequest(
+                componentId = 1000L,
+                elementId = "element-123",
+                targetUrl = "https://jeffrey-oh.click"
+            )
+        )
+
+        val command = request.toCommand()
+
+        every { saveEventUseCase.saveEvent(command) } returns Mono.empty()
+
+        // when
+        val result = eventHandler.saveEvent(request)
+
+        // then
+        StepVerifier.create(result)
+            .verifyComplete()
+
+        verify(exactly = 1) { saveEventUseCase.saveEvent(match { it.sessionId == "session-123" }) }
+    }
+
+}

--- a/event-application/build.gradle.kts
+++ b/event-application/build.gradle.kts
@@ -10,4 +10,9 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("io.projectreactor:reactor-core")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation("org.assertj:assertj-core:3.25.3")
+    testImplementation("io.projectreactor:reactor-test")
 }

--- a/event-application/src/test/kotlin/com/jeffreyoh/eventapplication/service/SaveEventServiceTest.kt
+++ b/event-application/src/test/kotlin/com/jeffreyoh/eventapplication/service/SaveEventServiceTest.kt
@@ -1,0 +1,64 @@
+package com.jeffreyoh.eventapplication.service
+
+import com.jeffreyoh.eventapplication.service.SaveEventService
+import com.jeffreyoh.eventcore.domain.event.Event
+import com.jeffreyoh.eventcore.domain.event.EventCommand
+import com.jeffreyoh.eventcore.domain.event.EventMetadata
+import com.jeffreyoh.eventcore.domain.event.EventType
+import com.jeffreyoh.eventport.input.SaveEventUseCase
+import com.jeffreyoh.eventport.output.SaveEventPort
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+@ExtendWith(MockKExtension::class)
+class SaveEventServiceTest {
+
+    @MockK private lateinit var saveEventPort: SaveEventPort
+    private lateinit var saveEventService: SaveEventUseCase
+
+    @BeforeEach
+    fun setUp() {
+        saveEventService = SaveEventService(saveEventPort)
+    }
+
+    @Test
+    fun `이벤트 command 를 전달받아 redis 저장 port가 호출된다`() {
+        // given
+        val command = EventCommand.SaveEventCommand(
+            eventType = EventType.CLICK,
+            userId = 1L,
+            sessionId = "session-123",
+            metadata = EventMetadata(
+                componentId = 1000L,
+                elementId = "element-123",
+                targetUrl = "https://jeffrey-oh.click"
+            )
+        )
+
+        val slot = slot<Event>()
+        val event = command.toEvent()
+
+        every { saveEventPort.saveToRedis(capture(slot)) } returns Mono.empty()
+
+        // when
+        val result = saveEventService.saveEvent(command)
+
+        // then
+        StepVerifier.create(result)
+            .verifyComplete()
+
+        assertThat(slot.captured)
+            .usingRecursiveComparison()
+            .ignoringFields("createdAt")
+            .isEqualTo(event)
+    }
+
+}

--- a/event-core/src/main/kotlin/com/jeffreyoh/eventcore/domain/event/EventMetadata.kt
+++ b/event-core/src/main/kotlin/com/jeffreyoh/eventcore/domain/event/EventMetadata.kt
@@ -1,8 +1,8 @@
 package com.jeffreyoh.eventcore.domain.event
 
 data class EventMetadata(
-    val componentId: Long? = null, // 요소 값이 가변적일 수 있으므로 실질적인 ID 별도 저장
-    val elementId: String? = null, // 프론트에서 사용하는 요소 값
+    val componentId: Long, // 요소 값이 가변적일 수 있으므로 실질적인 ID 별도 저장
+    val elementId: String, // 프론트에서 사용하는 요소 값
     val targetUrl: String? = null,
     val pageUrl: String? = null,
     val keyword: String? = null,

--- a/event-storage/build.gradle.kts
+++ b/event-storage/build.gradle.kts
@@ -13,4 +13,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
 
     implementation("io.projectreactor:reactor-core")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.mockk:mockk:1.13.9")
+    testImplementation("org.assertj:assertj-core:3.25.3")
+    testImplementation("io.projectreactor:reactor-test")
+    testImplementation("com.github.codemonstur:embedded-redis:1.4.3")
 }

--- a/event-storage/src/main/kotlin/com/jeffreyoh/eventstorage/config/RedisConfig.kt
+++ b/event-storage/src/main/kotlin/com/jeffreyoh/eventstorage/config/RedisConfig.kt
@@ -4,14 +4,14 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Configuration
-import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import java.util.function.Consumer
 
 private val log = KotlinLogging.logger {}
 
 @Configuration
 class RedisConfig(
-    val reactiveRedisTemplate: ReactiveRedisTemplate<String, String>
+    val reactiveRedisTemplate: ReactiveStringRedisTemplate
 ) : ApplicationListener<ApplicationReadyEvent> {
 
     override fun onApplicationEvent(event: ApplicationReadyEvent) {

--- a/event-storage/src/main/resources/application.properties
+++ b/event-storage/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=event-storage

--- a/event-storage/src/main/resources/application.yml
+++ b/event-storage/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  data:
+    redis:
+      host: localhost
+      port: 63790

--- a/event-storage/src/test/kotlin/com/jeffreyoh/eventstorage/adapter/outbound/redis/RedisEventWriterTest.kt
+++ b/event-storage/src/test/kotlin/com/jeffreyoh/eventstorage/adapter/outbound/redis/RedisEventWriterTest.kt
@@ -1,0 +1,80 @@
+package com.jeffreyoh.eventstorage.adapter.outbound.redis
+
+import com.jeffreyoh.eventcore.domain.event.Event
+import com.jeffreyoh.eventcore.domain.event.EventMetadata
+import com.jeffreyoh.eventcore.domain.event.EventType
+import com.jeffreyoh.eventcore.domain.event.toJson
+import io.lettuce.core.RestoreArgs.Builder.ttl
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.slot
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.data.redis.core.ReactiveRedisTemplate
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.ReactiveValueOperations
+import org.springframework.data.redis.core.ValueOperations
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@ExtendWith(MockKExtension::class)
+class RedisEventWriterTest {
+
+    @MockK private lateinit var redisTemplate: ReactiveStringRedisTemplate
+    private lateinit var redisEventWriter: RedisEventWriter
+
+    @BeforeEach
+    fun setUp() {
+        redisEventWriter = RedisEventWriter(redisTemplate)
+    }
+
+    @Test
+    fun `이벤트를 Redis에 저장한다`() {
+        // given
+        val event = Event(
+            eventType = EventType.CLICK,
+            userId = 1L,
+            sessionId = "session-123",
+            metadata = EventMetadata(
+                componentId = 1000L,
+                elementId = "element-123",
+                targetUrl = "https://jeffrey-oh.click"
+            ),
+            createdAt = LocalDateTime.now()
+        )
+
+        val opsMock = mockk<ReactiveValueOperations<String, String>>()
+        every { redisTemplate.opsForValue() } returns opsMock
+
+        val keySlot = slot<String>()
+        val valueSlot = slot<String>()
+        val ttlSlot = slot<Duration>()
+
+        every {
+            opsMock.set(capture(keySlot), capture(valueSlot), capture(ttlSlot))
+        } returns Mono.empty()
+
+        // when
+        val result = redisEventWriter.saveToRedis(event)
+
+        // then
+        StepVerifier.create(result)
+            .verifyComplete()
+
+        val expectedKey = "events:${event.eventType.name}:user:${event.userId}:${event.createdAt.toEpochSecond(ZoneOffset.UTC)}"
+        val expectedValue = event.toJson()
+        val expectedTtl = Duration.ofSeconds(10)
+
+        assertThat(keySlot.captured).isEqualTo(expectedKey)
+        assertThat(valueSlot.captured).isEqualTo(expectedValue)
+        assertThat(ttlSlot.captured).isEqualTo(expectedTtl)
+    }
+
+}


### PR DESCRIPTION
- `EventHandler`에 대한 단위 테스트 작성
- `usecase` 호출 및 전달 값 검증 (slot 기반)
- `SaveEventService`에 대한 단위 테스트 작성
- `SaveEventPort` 호출 여부 및 전달 데이터 검증
- `RedisEventWriter` 단위 테스트
- TTL 테스트 제외
- `WebTestClient`를 이용한 `controller` 테스트
- `handler` 호출 여부 및 전달값 검증
- `saveEventUseCase` mock 처리
- 필수 필드 누락 시 400 응답 테스트
- `eventType`, `sessionId`, `metadata` 하위 필드 등 검증
- `EventMetaData` 를 Request 와 도메인으로 구분하기 위해 클래스 추가 및 DTO 클래스 통합