### PR TITLE
Feat: 좋아요 취소 이벤트 추가

### DIFF
--- a/event-core/src/main/kotlin/com/jeffreyoh/eventcore/domain/event/EventType.kt
+++ b/event-core/src/main/kotlin/com/jeffreyoh/eventcore/domain/event/EventType.kt
@@ -4,5 +4,6 @@ enum class EventType {
     PAGE_VIEW,
     SEARCH,
     CLICK,
-    LIKE
+    LIKE,
+    UNLIKE
 }


### PR DESCRIPTION
- 기존 좋아요 로직에서 토글 방식으로 변경
- 따로 처리하지 않는 이유는 UI 상 좋아요는 1개 이기 때문에 트래커가 토글로 처리하는게 좋을 것 같음