### PR TITLE
Refactor: `StatisticsRedisPort` 메소드 추상화

### DIFF
--- a/event-tracker/event-api/src/main/kotlin/com/jeffreyoh/eventtracker/api/adapter/inbound/web/dto/SaveEventDTO.kt
+++ b/event-tracker/event-api/src/main/kotlin/com/jeffreyoh/eventtracker/api/adapter/inbound/web/dto/SaveEventDTO.kt
@@ -35,6 +35,10 @@ class SaveEventDTO {
                 throw ValidationException(HttpStatus.BAD_REQUEST, "metadata.postId is required for eventType: $eventType")
             }
 
+            if (metadata.elementId?.isBlank() == true) {
+                throw ValidationException(HttpStatus.BAD_REQUEST, "metadata.elementId is required")
+            }
+
             return EventCommand.SaveEventCommand(
                 eventType,
                 userId,
@@ -51,7 +55,7 @@ class SaveEventDTO {
 
     data class EventMetadataRequest(
         @field:Min(1) val componentId: Long, // 요소 값이 가변적일 수 있으므로 실질적인 ID 별도 저장
-        @field:NotBlank val elementId: String, // 프론트에서 사용하는 요소 값
+        val elementId: String? = null, // 프론트에서 사용하는 요소 값
         val keyword: String? = null,
         val postId: Long? = null,
     )

--- a/event-tracker/event-application/src/main/kotlin/com/jeffreyoh/eventtracker/application/service/GetStatisticsService.kt
+++ b/event-tracker/event-application/src/main/kotlin/com/jeffreyoh/eventtracker/application/service/GetStatisticsService.kt
@@ -1,5 +1,6 @@
 package com.jeffreyoh.eventtracker.application.service
 
+import com.jeffreyoh.eventtracker.core.domain.event.EventMetadata
 import com.jeffreyoh.eventtracker.core.domain.event.EventType
 import com.jeffreyoh.eventtracker.port.input.GetEventStatisticsUseCase
 import com.jeffreyoh.eventtracker.port.output.StatisticsRedisPort
@@ -11,16 +12,16 @@ class GetStatisticsService(
 
     override fun getCount(componentId: Long, eventType: EventType): Mono<Long> {
         return when(eventType) {
-            EventType.CLICK -> statisticsRedisPort.getClickCount(componentId)
-            EventType.PAGE_VIEW -> statisticsRedisPort.getPageViewCount(componentId)
-            EventType.SEARCH -> statisticsRedisPort.getSearchCount(componentId)
+            EventType.CLICK -> statisticsRedisPort.getEventCount(eventType, EventMetadata(componentId = componentId))
+            EventType.PAGE_VIEW -> statisticsRedisPort.getEventCount(eventType, EventMetadata(componentId = componentId))
+            EventType.SEARCH -> statisticsRedisPort.getEventCount(eventType, EventMetadata(componentId = componentId))
             EventType.LIKE -> Mono.error(IllegalArgumentException("Like count is not supported"))
             EventType.UNLIKE ->Mono.error(IllegalArgumentException("UnLike count is not supported"))
         }
     }
 
     override fun getLikeCount(componentId: Long, postId: Long): Mono<Long> {
-        return statisticsRedisPort.getLikeCount(componentId, postId)
+        return statisticsRedisPort.getEventCount(EventType.LIKE, EventMetadata(componentId = componentId, postId = postId))
     }
 
 }

--- a/event-tracker/event-application/src/main/kotlin/com/jeffreyoh/eventtracker/application/service/SaveEventService.kt
+++ b/event-tracker/event-application/src/main/kotlin/com/jeffreyoh/eventtracker/application/service/SaveEventService.kt
@@ -46,10 +46,10 @@ class SaveEventService(
             eventRedisPort.saveToRedis(event)
                 .then(
                     when(event.eventType) {
-                        EventType.CLICK -> statisticsRedisPort.incrementClick(event.metadata.componentId)
-                        EventType.PAGE_VIEW -> statisticsRedisPort.incrementPageView(event.metadata.componentId)
+                        EventType.CLICK -> statisticsRedisPort.incrementEventCount(event.eventType, event.metadata)
+                        EventType.PAGE_VIEW -> statisticsRedisPort.incrementEventCount(event.eventType, event.metadata)
                         EventType.SEARCH -> {
-                            statisticsRedisPort.incrementSearch(event.metadata.componentId)
+                            statisticsRedisPort.incrementEventCount(event.eventType, event.metadata)
                                 .then(recentSearchRedisPort.saveRecentKeyword(event.userId!!, event.metadata.keyword!!))
                         }
                         else -> Mono.empty()

--- a/event-tracker/event-application/src/test/kotlin/com/jeffreyoh/eventtracker/application/service/GetStatisticsServiceTest.kt
+++ b/event-tracker/event-application/src/test/kotlin/com/jeffreyoh/eventtracker/application/service/GetStatisticsServiceTest.kt
@@ -1,10 +1,12 @@
 package com.jeffreyoh.eventtracker.application.service
 
+import com.jeffreyoh.eventtracker.core.domain.event.EventMetadata
 import com.jeffreyoh.eventtracker.core.domain.event.EventType
 import com.jeffreyoh.eventtracker.port.output.StatisticsRedisPort
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -32,12 +34,15 @@ class GetStatisticsServiceTest {
         val componentId = 1000L
         val expectedCount = 500L
 
+        val eventTypeSlot = slot<EventType>()
+        val eventMetadataSlot = slot<EventMetadata>()
+
         every {
             when(eventType) {
-                EventType.CLICK -> statisticsRedisPort.getClickCount(componentId)
-                EventType.PAGE_VIEW -> statisticsRedisPort.getPageViewCount(componentId)
-                EventType.SEARCH -> statisticsRedisPort.getSearchCount(componentId)
-                EventType.LIKE -> statisticsRedisPort.getLikeCount(componentId, 1L) // postId는 임의로 설정
+                EventType.CLICK -> statisticsRedisPort.getEventCount(capture(eventTypeSlot), capture(eventMetadataSlot))
+                EventType.PAGE_VIEW -> statisticsRedisPort.getEventCount(capture(eventTypeSlot), capture(eventMetadataSlot))
+                EventType.SEARCH -> statisticsRedisPort.getEventCount(capture(eventTypeSlot), capture(eventMetadataSlot))
+                EventType.LIKE -> statisticsRedisPort.getEventCount(EventType.LIKE, capture(eventMetadataSlot))
                 else -> Mono.empty()
             }
         } returns Mono.just(expectedCount)
@@ -57,10 +62,10 @@ class GetStatisticsServiceTest {
 
         verify(exactly = 1) {
             when(eventType) {
-                EventType.CLICK -> statisticsRedisPort.getClickCount(componentId)
-                EventType.PAGE_VIEW -> statisticsRedisPort.getPageViewCount(componentId)
-                EventType.SEARCH -> statisticsRedisPort.getSearchCount(componentId)
-                EventType.LIKE -> statisticsRedisPort.getLikeCount(componentId, 1L) // postId는 임의로 설정
+                EventType.CLICK -> statisticsRedisPort.getEventCount(capture(eventTypeSlot), capture(eventMetadataSlot))
+                EventType.PAGE_VIEW -> statisticsRedisPort.getEventCount(capture(eventTypeSlot), capture(eventMetadataSlot))
+                EventType.SEARCH -> statisticsRedisPort.getEventCount(capture(eventTypeSlot), capture(eventMetadataSlot))
+                EventType.LIKE -> statisticsRedisPort.getEventCount(EventType.LIKE, capture(eventMetadataSlot))
                 else -> Mono.empty()
             }
         }

--- a/event-tracker/event-application/src/test/kotlin/com/jeffreyoh/eventtracker/application/service/SaveEventServiceTest.kt
+++ b/event-tracker/event-application/src/test/kotlin/com/jeffreyoh/eventtracker/application/service/SaveEventServiceTest.kt
@@ -17,6 +17,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 
@@ -37,30 +39,49 @@ class SaveEventServiceTest {
         )
     }
 
-    @Test
-    fun `이벤트 command 를 전달받아 redis 저장 port가 호출된다`() {
+    @ParameterizedTest
+    @EnumSource(EventType::class, mode = EnumSource.Mode.EXCLUDE, names = ["LIKE", "UNLIKE"])
+    fun `이벤트 command 를 전달받아 redis 저장 port가 호출된다`(eventType: EventType) {
         // given
         val command = EventCommand.SaveEventCommand(
-            eventType = EventType.CLICK,
+            eventType = eventType,
             userId = 1L,
             sessionId = "session-123",
             metadata = EventMetadata(
                 componentId = 1000L,
                 elementId = "element-123",
+                postId = 1L,
+                keyword = "keyword"
             )
         )
 
-        val slot = slot<Event>()
+        val eventSlot = slot<Event>()
+        val eventTypeSlot = slot<EventType>()
+        val eventMetadataSlot = slot<EventMetadata>()
+        val userIdSlot = slot<Long>()
+        val keywordSlot = slot<String>()
+
         val event = command.toEvent()
 
         every {
-            eventRedisPort.saveToRedis(capture(slot))
+            eventRedisPort.saveToRedis(capture(eventSlot))
                 .then(
-                    when(event.eventType) {
-                        EventType.CLICK -> statisticsRedisPort.incrementClick(event.metadata.componentId)
-                        EventType.PAGE_VIEW -> statisticsRedisPort.incrementPageView(event.metadata.componentId)
-                        EventType.SEARCH -> statisticsRedisPort.incrementSearch(event.metadata.componentId)
-                        EventType.LIKE -> statisticsRedisPort.incrementLike(event.metadata.componentId, 1L) // postId는 임의로 설정
+                    when (eventType) {
+                        EventType.CLICK -> statisticsRedisPort.incrementEventCount(
+                            capture(eventTypeSlot),
+                            capture(eventMetadataSlot)
+                        )
+
+                        EventType.PAGE_VIEW -> statisticsRedisPort.incrementEventCount(
+                            capture(eventTypeSlot),
+                            capture(eventMetadataSlot)
+                        )
+
+                        EventType.SEARCH -> statisticsRedisPort.incrementEventCount(
+                            capture(eventTypeSlot),
+                            capture(eventMetadataSlot)
+                        ).then(recentSearchRedisPort.saveRecentKeyword(capture(userIdSlot), capture(keywordSlot)))
+
                         else -> Mono.empty()
                     }
                 )
@@ -73,19 +94,116 @@ class SaveEventServiceTest {
         StepVerifier.create(result)
             .verifyComplete()
 
-        assertThat(slot.captured)
+        assertThat(eventSlot.captured)
             .usingRecursiveComparison()
             .ignoringFields("createdAt")
             .isEqualTo(event)
 
         verify(exactly = 1) {
-            when(event.eventType) {
-                EventType.CLICK -> statisticsRedisPort.incrementClick(event.metadata.componentId)
-                EventType.PAGE_VIEW -> statisticsRedisPort.incrementPageView(event.metadata.componentId)
-                EventType.SEARCH -> statisticsRedisPort.incrementSearch(event.metadata.componentId)
-                EventType.LIKE -> statisticsRedisPort.incrementLike(event.metadata.componentId, 1L) // postId는 임의로 설정
-                else -> Mono.empty()
-            }
+            eventRedisPort.saveToRedis(capture(eventSlot))
+                .then(
+                    when (eventType) {
+                        EventType.CLICK -> statisticsRedisPort.incrementEventCount(
+                            capture(eventTypeSlot),
+                            capture(eventMetadataSlot)
+                        )
+
+                        EventType.PAGE_VIEW -> statisticsRedisPort.incrementEventCount(
+                            capture(eventTypeSlot),
+                            capture(eventMetadataSlot)
+                        )
+
+                        EventType.SEARCH -> statisticsRedisPort.incrementEventCount(
+                            capture(eventTypeSlot),
+                            capture(eventMetadataSlot)
+                        ).then(recentSearchRedisPort.saveRecentKeyword(capture(userIdSlot), capture(keywordSlot)))
+
+                        else -> Mono.empty()
+                    }
+                )
+        }
+
+    }
+
+    @Test
+    fun `LIKE 이벤트 - 캐시에 없으면 저장한다`() {
+        // given
+        val command = EventCommand.SaveEventCommand(
+            eventType = EventType.LIKE,
+            userId = 1L,
+            sessionId = "session-123",
+            metadata = EventMetadata(
+                componentId = 1000L,
+                elementId = "element-123",
+                postId = 1L,
+                keyword = "keyword"
+            )
+        )
+
+        val eventSlot = slot<Event>()
+        val keySlot = slot<String>()
+        val componentIdSlot = slot<Long>()
+        val postIdSlot = slot<Long>()
+
+        val event = command.toEvent()
+
+        every { eventRedisPort.readLikeFromRedisKey(capture(keySlot)) } returns Mono.empty()
+        every { eventRedisPort.saveLikeEventToRedis(capture(keySlot), capture(eventSlot)) } returns Mono.empty()
+        every { statisticsRedisPort.incrementLike(capture(componentIdSlot), capture(postIdSlot)) } returns Mono.empty()
+
+        // when
+        val result = saveEventService.saveEvent(command)
+
+        // then
+        StepVerifier.create(result)
+            .verifyComplete()
+
+        assertThat(eventSlot.captured)
+            .usingRecursiveComparison()
+            .ignoringFields("createdAt")
+            .isEqualTo(event)
+
+        verify(exactly = 1) {
+            eventRedisPort.readLikeFromRedisKey(capture(keySlot))
+            eventRedisPort.saveLikeEventToRedis(capture(keySlot), capture(eventSlot))
+            statisticsRedisPort.incrementLike(capture(componentIdSlot), capture(postIdSlot))
+        }
+    }
+
+    @Test
+    fun `LIKE 이벤트 - 캐시에 이미 있으면 삭제한다`() {
+        // given
+        val command = EventCommand.SaveEventCommand(
+            eventType = EventType.LIKE,
+            userId = 1L,
+            sessionId = "session-123",
+            metadata = EventMetadata(
+                componentId = 1000L,
+                elementId = "element-123",
+                postId = 1L,
+                keyword = "keyword"
+            )
+        )
+
+        val keySlot = slot<String>()
+        val componentIdSlot = slot<Long>()
+        val postIdSlot = slot<Long>()
+
+        every { eventRedisPort.readLikeFromRedisKey(capture(keySlot)) } returns Mono.just("cached")
+        every { eventRedisPort.deleteFromRedisKey(capture(keySlot)) } returns Mono.empty()
+        every { statisticsRedisPort.decrementLike(capture(componentIdSlot), capture(postIdSlot)) } returns Mono.empty()
+
+        // when
+        val result = saveEventService.saveEvent(command)
+
+        // then
+        StepVerifier.create(result)
+            .verifyComplete()
+
+        verify(exactly = 1) {
+            eventRedisPort.readLikeFromRedisKey(capture(keySlot))
+            eventRedisPort.deleteFromRedisKey(capture(keySlot))
+            statisticsRedisPort.decrementLike(capture(componentIdSlot), capture(postIdSlot))
         }
     }
 

--- a/event-tracker/event-core/src/main/kotlin/com/jeffreyoh/eventtracker/core/domain/event/EventMetadata.kt
+++ b/event-tracker/event-core/src/main/kotlin/com/jeffreyoh/eventtracker/core/domain/event/EventMetadata.kt
@@ -2,7 +2,7 @@ package com.jeffreyoh.eventtracker.core.domain.event
 
 data class EventMetadata(
     val componentId: Long, // 요소 값이 가변적일 수 있으므로 실질적인 ID 별도 저장
-    val elementId: String, // 프론트에서 사용하는 요소 값
+    val elementId: String? = null, // 프론트에서 사용하는 요소 값
     val keyword: String? = null,
     val postId: Long? = null,
 )

--- a/event-tracker/event-core/src/main/kotlin/com/jeffreyoh/eventtracker/core/domain/event/EventType.kt
+++ b/event-tracker/event-core/src/main/kotlin/com/jeffreyoh/eventtracker/core/domain/event/EventType.kt
@@ -1,9 +1,39 @@
 package com.jeffreyoh.eventtracker.core.domain.event
 
-enum class EventType {
-    PAGE_VIEW,
-    SEARCH,
-    CLICK,
-    LIKE,
-    UNLIKE
+enum class EventType(
+    val eventName: String,
+    val description: String,
+    val groupId: Long,
+    val componentId: Long,
+) {
+    PAGE_VIEW(
+        eventName = "page_view",
+        description = "페이지 조회",
+        groupId = 1L,
+        componentId = 1000L
+    ),
+    SEARCH(
+        eventName = "search",
+        description = "검색",
+        groupId = 2L,
+        componentId = 1001L
+    ),
+    CLICK(
+        eventName = "click",
+        description = "클릭",
+        groupId = 3L,
+        componentId = 1002L
+    ),
+    LIKE(
+        eventName = "like",
+        description = "좋아요",
+        groupId = 4L,
+        componentId = 1003L
+    ),
+    UNLIKE(
+        eventName = "like",
+        description = "싫어요",
+        groupId = 4L,
+        componentId = 1003L
+    ),
 }

--- a/event-tracker/event-port/src/main/kotlin/com/jeffreyoh/eventtracker/port/output/StatisticsRedisPort.kt
+++ b/event-tracker/event-port/src/main/kotlin/com/jeffreyoh/eventtracker/port/output/StatisticsRedisPort.kt
@@ -1,17 +1,13 @@
 package com.jeffreyoh.eventtracker.port.output
 
+import com.jeffreyoh.eventtracker.core.domain.event.EventMetadata
+import com.jeffreyoh.eventtracker.core.domain.event.EventType
 import reactor.core.publisher.Mono
 
 interface StatisticsRedisPort {
 
-    fun getLikeCount(componentId: Long, postId: Long): Mono<Long>
-    fun getClickCount(componentId: Long): Mono<Long>
-    fun getPageViewCount(componentId: Long): Mono<Long>
-    fun getSearchCount(componentId: Long): Mono<Long>
-
-    fun incrementClick(componentId: Long): Mono<Void>
-    fun incrementPageView(componentId: Long): Mono<Void>
-    fun incrementSearch(componentId: Long): Mono<Void>
+    fun incrementEventCount(eventType: EventType, metadata: EventMetadata): Mono<Void>
+    fun getEventCount(eventType: EventType, metadata: EventMetadata): Mono<Long>
 
     fun incrementLike(componentId: Long, postId: Long): Mono<Void>
     fun decrementLike(componentId: Long, postId: Long): Mono<Void>

--- a/user-service/user-storage/src/main/kotlin/com/jeffreyoh/userservice/storage/adapter/eventtracker/dto/EventTrackerOutboundDTO.kt
+++ b/user-service/user-storage/src/main/kotlin/com/jeffreyoh/userservice/storage/adapter/eventtracker/dto/EventTrackerOutboundDTO.kt
@@ -13,7 +13,7 @@ class EventTrackerOutboundDTO {
 
     data class EventMetadata(
         val componentId: Long,
-        val elementId: String,
+        val elementId: String? = null,
         val keyword: String? = null,
         val postId: Long? = null,
     )


### PR DESCRIPTION
- `SaveEventServiceTest` 단위 테스트 케이스 중 `LIKE` 이벤트 분리
- `StatisticsRedisAdapterTest` 단위 테스트 수정