### PR TITLE
Refactor: Redis Scan 명령어 제거 및 ZSET 사용

### DIFF
--- a/event-tracker/event-application/src/main/kotlin/com/jeffreyoh/eventtracker/application/port/out/StatisticsRedisPort.kt
+++ b/event-tracker/event-application/src/main/kotlin/com/jeffreyoh/eventtracker/application/port/out/StatisticsRedisPort.kt
@@ -1,5 +1,6 @@
 package com.jeffreyoh.eventtracker.application.port.out
 
+import com.jeffreyoh.enums.EventType
 import com.jeffreyoh.eventtracker.application.model.event.EventRedisQuery
 import com.jeffreyoh.eventtracker.application.model.statistics.GetStatisticsRedisQuery
 import reactor.core.publisher.Flux
@@ -10,7 +11,8 @@ interface StatisticsRedisPort {
     fun saveEventCount(query: EventRedisQuery): Mono<Void>
     fun getEventCount(query: GetStatisticsRedisQuery): Mono<Long>
 
-    fun scan(): Flux<String>
     fun saveCountSnapshot(key: String): Mono<Long>
+
+    fun getEventCountsForHour(eventType: EventType, time: String): Flux<Pair<String, Long>>
 
 }

--- a/event-tracker/event-storage/src/main/kotlin/com/jeffreyoh/eventtracker/storage/adapter/outbound/redis/StatisticsRedisAdapter.kt
+++ b/event-tracker/event-storage/src/main/kotlin/com/jeffreyoh/eventtracker/storage/adapter/outbound/redis/StatisticsRedisAdapter.kt
@@ -5,27 +5,34 @@ import com.jeffreyoh.eventtracker.application.model.event.EventRedisQuery
 import com.jeffreyoh.eventtracker.application.model.statistics.GetStatisticsRedisQuery
 import com.jeffreyoh.eventtracker.application.port.out.StatisticsRedisPort
 import com.jeffreyoh.eventtracker.core.domain.event.EventMetadata
-import org.springframework.data.redis.core.ReactiveRedisTemplate
-import org.springframework.data.redis.core.ScanOptions
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.data.redis.core.script.RedisScript
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Component
 class StatisticsRedisAdapter(
-    private val redisTemplate: ReactiveRedisTemplate<String, Long>
+    private val redisTemplate: ReactiveStringRedisTemplate
 ): StatisticsRedisPort {
 
     override fun saveEventCount(query: EventRedisQuery): Mono<Void> {
-        val key = buildKey(query.eventType, query.metadata)
+        val zsetKey = buildZSetKey(query.eventType)
+        val member = buildZSetMember(query.metadata)
 
         if (query.eventType == EventType.UNLIKE)
-            return decrementLike(query.metadata.componentId, query.metadata.postId!!)
+            return decrementLike(zsetKey, member)
 
-        return redisTemplate.opsForValue()
-            .increment(key)
-            .then()
+        return redisTemplate.opsForZSet()
+            .incrementScore(zsetKey, member, 1.0)
+            .then(
+                redisTemplate.expire(zsetKey, Duration.ofMinutes(10))
+                    .then()
+            )
     }
 
     override fun getEventCount(query: GetStatisticsRedisQuery): Mono<Long> {
@@ -40,47 +47,56 @@ class StatisticsRedisAdapter(
         return redisTemplate.opsForValue().get(key).map { it.toLong() }.defaultIfEmpty(0L)
     }
 
+    private fun buildZSetKey(eventType: EventType): String {
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"))
+        return "statistics:${eventType.name.lowercase()}:$timestamp"
+    }
+
+    private fun buildZSetMember(metadata: EventMetadata): String {
+        val member = "component:${metadata.componentId}"
+        return when {
+            metadata.postId != null -> "$member:post:${metadata.postId}"
+            metadata.keyword != null -> "$member:keyword:${metadata.keyword}"
+            else -> member
+        }
+    }
+
     private fun buildKey(eventType: EventType, metadata: EventMetadata): String {
-        val key = "statistics:${eventType.name.lowercase()}:component:${metadata.componentId}"
-        return when (eventType) {
+        var key = "statistics:${eventType.name.lowercase()}:component:${metadata.componentId}"
+        key = when (eventType) {
             EventType.SEARCH -> "$key:keyword:${metadata.keyword}"
             EventType.LIKE, EventType.UNLIKE ->
                 "statistics:${EventType.LIKE.name.lowercase()}:component:${metadata.componentId}:post:${metadata.postId}"
             else -> key
         }
+        return "$key:${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"))}"
     }
 
-    fun decrementLike(
-        componentId: Long,
-        postId: Long
-    ): Mono<Void> {
-        val key = buildKey(EventType.UNLIKE, EventMetadata(componentId = EventType.UNLIKE.componentId, postId = postId))
+    fun decrementLike(zsetKey: String, member: String): Mono<Void> {
         val luaScript = RedisScript.of(
             """
-            local current = redis.call('GET', KEYS[1])
+            local current = redis.call('ZSCORE', KEYS[1], ARGV[1])
             if current and tonumber(current) > 0 then
-                return redis.call('DECR', KEYS[1])
+                return redis.call('ZINCRBY', KEYS[1], -1, ARGV[1])
             else
                 return current or 0
             end
-            """.trimIndent(),
-            Long::class.java
+            """.trimIndent(), Long::class.java
         )
-        return redisTemplate.execute(luaScript, listOf(key))
+        return redisTemplate.execute(luaScript, listOf(zsetKey), listOf(member))
             .then()
     }
 
-    override fun scan(): Flux<String> {
-        return redisTemplate.scan(
-            ScanOptions.scanOptions()
-                .match("statistics:*")
-                .count(1000)
-                .build()
-        )
+    override fun getEventCountsForHour(eventType: EventType, time: String): Flux<Pair<String, Long>> {
+        val key = "statistics:${eventType.name.lowercase()}:$time"
+        return redisTemplate.opsForZSet()
+            .rangeWithScores(key, Range.unbounded())
+            .map { it.value!! to it.score!!.toLong() }
     }
 
     override fun saveCountSnapshot(key: String): Mono<Long> {
-        val script = RedisScript.of("""
+        val script = RedisScript.of(
+            """
                 local current = tonumber(redis.call('GET', KEYS[1]) or '0')
                 local snapshot = tonumber(redis.call('GET', KEYS[2]) or '0')
                 local delta = current - snapshot


### PR DESCRIPTION
- 1분 단위로 key 를 저장하고 member+score 로 해당 이벤트의 멤버들을 모두 저장
- 이벤트 발생 시 zincrby 처리
- 스케줄러에서 -1분 기준으로 zrangebyscore -inf +inf 범위로 조회하여 모두 통계 DB 적재